### PR TITLE
Add responsive scaling

### DIFF
--- a/static/css/jurassicSystems.css
+++ b/static/css/jurassicSystems.css
@@ -8,8 +8,16 @@ body {
    height: 100%;
 }
 
+#scale-container {
+   width: 100%;
+   height: 100%;
+   position: relative;
+   overflow: hidden;
+}
+
 #environment {
    position: relative;
+   transform-origin: top left;
 }
 
 #irix-boot {

--- a/static/css/theKing.css
+++ b/static/css/theKing.css
@@ -6,6 +6,13 @@ body {
    background: black;
 }
 
+#scale-container {
+   width: 100%;
+   height: 100%;
+   position: relative;
+   overflow: hidden;
+}
+
 #environment {
    position: relative;
 }
@@ -31,6 +38,7 @@ body {
    width: 1124px;
    height: 850px;
    border-radius: 10px;
+   transform-origin: top left;
 }
 
 #the-king-window {

--- a/static/js/jurassicSystems.js
+++ b/static/js/jurassicSystems.js
@@ -435,7 +435,20 @@
     $('.buffer').blur();
   };
 
+  const scaleEnvironment = function() {
+    const env = $('#environment');
+    const container = $('#scale-container');
+    const baseW = env.data('base-width') || env.outerWidth();
+    const baseH = env.data('base-height') || env.outerHeight();
+    env.data('base-width', baseW);
+    env.data('base-height', baseH);
+    const scale = Math.min(container.width() / baseW, container.height() / baseH);
+    env.css('transform', 'scale(' + scale + ')');
+  };
+
   $(document).ready(function() {
+    scaleEnvironment();
+    $(window).on('resize', scaleEnvironment);
     // attempt to cache objects
     $(['theKingBlur.jpg',
       'theKingFocus.jpg',

--- a/static/js/theKing.js
+++ b/static/js/theKing.js
@@ -1,4 +1,14 @@
 (function($) {
+   const scaleEnvironment = function() {
+      const env = $('#apple-desktop');
+      const container = $('#scale-container');
+      const baseW = env.data('base-width') || env.outerWidth();
+      const baseH = env.data('base-height') || env.outerHeight();
+      env.data('base-width', baseW);
+      env.data('base-height', baseH);
+      const scale = Math.min(container.width() / baseW, container.height() / baseH);
+      env.css('transform', 'scale(' + scale + ')');
+   };
    $.ajax({
       url : '/swf/theKing.swf'
    });
@@ -8,6 +18,9 @@
       'macHDFocus.jpg']).each(function() {
          $('<img />')[0].src = '/img/' + this;
       });
+
+   scaleEnvironment();
+   $(window).on('resize', scaleEnvironment);
 
    (function() {
       var diffX = 0;

--- a/static/jurassicSystems.html
+++ b/static/jurassicSystems.html
@@ -29,6 +29,7 @@
       <div id="intro-text">Watch the above scene from Jurassic Park, then hold on to your butts and press continue to launch the recreation. Type <strong>"help"</strong> into the console to see a list of commands.</div><div id="intro-divider"></div><div id="continue-button"><img src="/img/continueButton.png"></div>
    </div>
 </div>
+<div id="scale-container">
 <div id="environment">
    <div id="irix-desktop">
       <div class="irix-window" id="main-terminal" style="z-index: 2">
@@ -166,6 +167,7 @@
       <div id="the-king-blur"></div>
       </div>
    </div>
+</div>
 </div>
    <script src="/js/lib/jquery.js"></script>
    <script src="/js/lib/soundmanager2-nodebug-jsmin.js"></script>

--- a/static/theKing.html
+++ b/static/theKing.html
@@ -21,6 +21,7 @@
    <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
    <![endif]-->
 <div id="home-key"><a href="/about"><img src="/img/homeKey.jpg" /></a></div>
+<div id="scale-container">
 <div id="apple-desktop">
    <div id="mac-hd-window">
    </div>
@@ -43,6 +44,7 @@
       </div>
       <div id="the-king-blur"></div>
    </div>
+</div>
 </div>
    <script src="/js/lib/jquery.js" type="text/javascript"></script>
    <script src="/js/theKing.js" type="text/javascript"></script>


### PR DESCRIPTION
## Summary
- wrap main environments in `#scale-container`
- add `scaleEnvironment` function for responsive scaling
- apply transform scaling on resize in both environments

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852b32adb84832f827b4ad41726890d